### PR TITLE
Logic for signing up new subscribers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linkify"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96dd5884008358112bc66093362197c7248ece00d46624e2cf71e50029f8cff5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,9 +2526,11 @@ dependencies = [
  "fake",
  "http",
  "hyper",
+ "linkify",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
+ "rand 0.8.5",
  "reqwest",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde-aux = "4.1.2"
 unicode-segmentation = "1.10.0"
 validator = "0.16.0"
 axum = "0.6.1"
+rand = { version = "0.8.5", features = ["std_rng"] }
 
 [dependencies.sqlx]
 version = "0.6.2"
@@ -48,6 +49,7 @@ features = ["json", "rustls-tls"]
 [dev-dependencies]
 claims = "0.7.1"
 fake = "~2.3.0"
+linkify = "0.9.0"
 once_cell = "1.16.0"
 quickcheck = "0.9.2"
 quickcheck_macros = "0.9.1"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # zero2prod
 
+### Pre-commit checks
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -- -D warnings
+cargo test
+```
+
 ### Migrations
 
 For prod migrations, run `DATABASE_URL="" sqlx migrate run`

--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -1,4 +1,5 @@
 application:
   host: "127.0.0.1"
+  base_url: "http://127.0.0.1"
 database:
   require_ssl: false

--- a/spec.yaml
+++ b/spec.yaml
@@ -31,6 +31,9 @@ services:
       - key: APP_DATABASE__DATABASE_NAME
         scope: RUN_TIME
         value: ${newsletter.DATABASE}
+      - key: APP_APPLICATION__BASE_URL
+        scope: RUN_TIME
+        value: ${APP_URL}
 databases:
   - engine: PG
     name: newsletter

--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -1,6 +1,6 @@
 {
   "db": "PostgreSQL",
-  "47f75dd99429be8147af1e9cc17dad35e73389801d282d4d1b396fece37a5980": {
+  "06dd4909b0120f49979a991165277b778d2b1ca6271ef47732ba2395b9c948b7": {
     "describe": {
       "columns": [],
       "nullable": [],
@@ -13,6 +13,51 @@
         ]
       }
     },
-    "query": "\n            INSERT INTO subscriptions (id, email, name, subscribed_at, status)\n            VALUES ($1, $2, $3, $4, 'confirmed')\n        "
+    "query": "\n            INSERT INTO subscriptions (id, email, name, subscribed_at, status)\n            VALUES ($1, $2, $3, $4, 'pending_confirmation')\n        "
+  },
+  "9ca563dbb06bcd0041ceff538c654dec2441ea0959fa67d4d7bcfeffad442654": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "INSERT INTO subscription_tokens (subscription_token, subscriber_id)\n        VALUES ($1, $2)"
+  },
+  "a71a1932b894572106460ca2e34a63dc0cb8c1ba7a70547add1cddbb68133c2b": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Uuid"
+        ]
+      }
+    },
+    "query": "UPDATE subscriptions SET status = 'confirmed' WHERE id = $1"
+  },
+  "ad120337ee606be7b8d87238e2bb765d0da8ee61b1a3bc142414c4305ec5e17f": {
+    "describe": {
+      "columns": [
+        {
+          "name": "subscriber_id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        }
+      ],
+      "nullable": [
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Text"
+        ]
+      }
+    },
+    "query": "SELECT subscriber_id FROM subscription_tokens WHERE subscription_token = $1"
   }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -40,6 +40,7 @@ pub struct ApplicationSettings {
     #[serde(deserialize_with = "deserialize_number_from_string")]
     pub port: u16,
     pub host: String,
+    pub base_url: String,
 }
 
 #[derive(serde::Deserialize, Clone)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,7 @@
 mod health_check;
 mod subscriptions;
+mod subscriptions_confirm;
 
 pub use health_check::health_check;
 pub use subscriptions::{subscribe, FormData};
+pub use subscriptions_confirm::confirm;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -6,11 +6,13 @@ use axum::{
     response::IntoResponse,
 };
 use chrono::Utc;
-use sqlx::PgPool;
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
+use sqlx::{Postgres, Transaction};
 use uuid::Uuid;
 
 use crate::{
     domain::{NewSubscriber, SubscriberEmail, SubscriberName},
+    email_client::EmailClient,
     startup::AppState,
 };
 
@@ -47,35 +49,131 @@ pub async fn subscribe(
         Err(_) => return StatusCode::BAD_REQUEST,
     };
 
-    match insert_subscriber(&app_state.pool, &new_subscriber).await {
-        Ok(_) => StatusCode::OK,
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    let mut transaction = match app_state.pool.begin().await {
+        Ok(transaction) => transaction,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
+    };
+
+    let subscriber_id = match insert_subscriber(&mut transaction, &new_subscriber).await {
+        Ok(subscriber_id) => subscriber_id,
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
+    };
+    let subscription_token = generate_subscription_token();
+
+    if store_token(&mut transaction, subscriber_id, &subscription_token)
+        .await
+        .is_err()
+    {
+        return StatusCode::INTERNAL_SERVER_ERROR;
     }
+
+    if transaction.commit().await.is_err() {
+        return StatusCode::INTERNAL_SERVER_ERROR;
+    }
+
+    // Send an email to the new subscriber
+    if send_confirmation_email(
+        &app_state.email_client,
+        new_subscriber,
+        &app_state.application_base_url,
+        &subscription_token,
+    )
+    .await
+    .is_err()
+    {
+        return StatusCode::INTERNAL_SERVER_ERROR;
+    }
+
+    StatusCode::OK
 }
 
 #[tracing::instrument(
-    name = "Saving new subscriber details in the database",
-    skip(new_subscriber, pool)
+    name = "Store subscription token in the database",
+    skip(subscription_token, transaction)
 )]
-pub async fn insert_subscriber(
-    pool: &PgPool,
-    new_subscriber: &NewSubscriber,
+pub async fn store_token(
+    transaction: &mut Transaction<'_, Postgres>,
+    subscriber_id: Uuid,
+    subscription_token: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query!(
-        r#"
-            INSERT INTO subscriptions (id, email, name, subscribed_at, status)
-            VALUES ($1, $2, $3, $4, 'confirmed')
-        "#,
-        Uuid::new_v4(),
-        new_subscriber.email.as_ref(),
-        new_subscriber.name.as_ref(),
-        Utc::now()
+        r#"INSERT INTO subscription_tokens (subscription_token, subscriber_id)
+        VALUES ($1, $2)"#,
+        subscription_token,
+        subscriber_id,
     )
-    .execute(pool)
+    .execute(transaction)
     .await
     .map_err(|e| {
         tracing::error!("Failed to execute query: {:?}", e);
         e
     })?;
     Ok(())
+}
+
+#[tracing::instrument(
+    name = "Send a confirmation email to a new subscriber",
+    skip(email_client, new_subscriber, application_base_url, subscription_token)
+)]
+pub async fn send_confirmation_email(
+    email_client: &EmailClient,
+    new_subscriber: NewSubscriber,
+    application_base_url: &str,
+    subscription_token: &str,
+) -> Result<(), reqwest::Error> {
+    let confirmation_link = format!(
+        "{}/subscriptions/confirm?subscription_token={}",
+        application_base_url, subscription_token
+    );
+    let html_content = format!("Welcome to our newsletter!<br />Click <a href=\"{}\">here</a> to confirm your subscription.", confirmation_link);
+    let text_content = format!(
+        "Welcome to our newsletter!\nVisit {} to confirm your subscription.",
+        confirmation_link
+    );
+
+    email_client
+        .send_email(
+            new_subscriber.email,
+            "Welcome!",
+            &html_content,
+            &text_content,
+        )
+        .await
+}
+
+#[tracing::instrument(
+    name = "Saving new subscriber details in the database",
+    skip(new_subscriber, transaction)
+)]
+pub async fn insert_subscriber(
+    transaction: &mut Transaction<'_, Postgres>,
+    new_subscriber: &NewSubscriber,
+) -> Result<Uuid, sqlx::Error> {
+    let subscriber_id = Uuid::new_v4();
+    sqlx::query!(
+        r#"
+            INSERT INTO subscriptions (id, email, name, subscribed_at, status)
+            VALUES ($1, $2, $3, $4, 'pending_confirmation')
+        "#,
+        subscriber_id,
+        new_subscriber.email.as_ref(),
+        new_subscriber.name.as_ref(),
+        Utc::now()
+    )
+    .execute(transaction)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+    Ok(subscriber_id)
+}
+
+/// Generate a random 25-character long case-sensitive subscription token
+fn generate_subscription_token() -> String {
+    let mut rng = thread_rng();
+    std::iter::repeat_with(|| rng.sample(Alphanumeric))
+        .map(char::from)
+        .take(25)
+        .collect()
 }

--- a/src/routes/subscriptions_confirm.rs
+++ b/src/routes/subscriptions_confirm.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::startup::AppState;
+
+#[derive(serde::Deserialize)]
+pub struct Parameters {
+    subscription_token: String,
+}
+
+#[tracing::instrument(name = "Confirm a pending subscriber", skip(parameters, app_state))]
+pub async fn confirm(
+    State(app_state): State<Arc<AppState>>,
+    Query(parameters): Query<Parameters>,
+) -> impl IntoResponse {
+    let id =
+        match get_subscriber_id_from_token(&app_state.pool, &parameters.subscription_token).await {
+            Ok(id) => id,
+            Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
+        };
+
+    if let Some(subscriber_id) = id {
+        if confirm_subscriber(&app_state.pool, subscriber_id)
+            .await
+            .is_err()
+        {
+            return StatusCode::INTERNAL_SERVER_ERROR;
+        }
+        StatusCode::OK
+    } else {
+        StatusCode::UNAUTHORIZED
+    }
+}
+
+#[tracing::instrument(name = "Mark subscriber as confirmed", skip(subscriber_id, pool))]
+pub async fn confirm_subscriber(pool: &PgPool, subscriber_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"UPDATE subscriptions SET status = 'confirmed' WHERE id = $1"#,
+        subscriber_id
+    )
+    .execute(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+
+    Ok(())
+}
+
+#[tracing::instrument(name = "Get subscriber_id from token", skip(subscription_token, pool))]
+pub async fn get_subscriber_id_from_token(
+    pool: &PgPool,
+    subscription_token: &str,
+) -> Result<Option<Uuid>, sqlx::Error> {
+    let result = sqlx::query!(
+        "SELECT subscriber_id FROM subscription_tokens \
+      WHERE subscription_token = $1",
+        subscription_token
+    )
+    .fetch_optional(pool)
+    .await
+    .map_err(|e| {
+        tracing::error!("Failed to execute query: {:?}", e);
+        e
+    })?;
+
+    Ok(result.map(|r| r.subscriber_id))
+}

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -1,6 +1,7 @@
 use once_cell::sync::Lazy;
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 use uuid::Uuid;
+use wiremock::MockServer;
 use zero2prod::{
     configuration::{get_configuration, DatabaseSettings},
     startup::{build, get_connection_pool},
@@ -26,9 +27,44 @@ static TRACING: Lazy<()> = Lazy::new(|| {
 pub struct TestApp {
     pub address: String,
     pub db_pool: PgPool,
+    pub email_server: MockServer,
+    pub port: u16,
+}
+
+/// Confirmation links embedded in the request to the email API
+pub struct ConfirmationLinks {
+    pub html: reqwest::Url,
+    pub plain_text: reqwest::Url,
 }
 
 impl TestApp {
+    /// Extract the confirmation links embedded in the request to the email API
+    pub fn get_confirmation_links(&self, email_request: &wiremock::Request) -> ConfirmationLinks {
+        let body: serde_json::Value = serde_json::from_slice(&email_request.body).unwrap();
+
+        // Extract the link from one of the request fields
+        let get_link = |s: &str| {
+            let links: Vec<_> = linkify::LinkFinder::new()
+                .links(s)
+                .filter(|l| *l.kind() == linkify::LinkKind::Url)
+                .collect();
+
+            assert_eq!(links.len(), 1);
+
+            let raw_link = links[0].as_str().to_owned();
+            let mut confirmation_link = reqwest::Url::parse(&raw_link).unwrap();
+            // Make sure we dont call random APIs on the web
+            assert_eq!(confirmation_link.host_str().unwrap(), "127.0.0.1");
+            confirmation_link.set_port(Some(self.port)).unwrap();
+
+            confirmation_link
+        };
+
+        let html = get_link(body["HtmlBody"].as_str().unwrap());
+        let plain_text = get_link(body["TextBody"].as_str().unwrap());
+        ConfirmationLinks { html, plain_text }
+    }
+
     pub async fn post_subscriptions(&self, body: String) -> reqwest::Response {
         reqwest::Client::new()
             .post(&format!("{}/subscriptions", &self.address))
@@ -45,6 +81,8 @@ pub async fn spawn_app() -> TestApp {
     // All other invocations will skip it
     Lazy::force(&TRACING);
 
+    let email_server = MockServer::start().await;
+
     let configuration = {
         let mut c = get_configuration().expect("Failed to read configuration");
 
@@ -53,6 +91,9 @@ pub async fn spawn_app() -> TestApp {
 
         // Use random OS port
         c.application.port = 0;
+
+        // Use the mock server as email API
+        c.email_client.base_url = email_server.uri();
 
         c
     };
@@ -64,12 +105,21 @@ pub async fn spawn_app() -> TestApp {
         .expect("Failed to build application");
 
     let address = format!("http://{}", server.local_addr());
+    let port = address
+        .as_str()
+        .split(':')
+        .last()
+        .expect("Failed to get application port")
+        .parse::<u16>()
+        .expect("Failed to convert port to u16");
 
     let _ = tokio::spawn(server);
 
     TestApp {
         address,
         db_pool: get_connection_pool(&configuration.database),
+        email_server,
+        port,
     }
 }
 

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,3 +1,4 @@
 mod health_check;
 mod helpers;
 mod subscriptions;
+mod subscriptions_confirm;

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -1,3 +1,8 @@
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
+
 use crate::helpers::spawn_app;
 
 #[tokio::test]
@@ -6,17 +11,41 @@ async fn subscribe_returns_a_200_for_valid_form_data() {
 
     let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
 
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&test_app.email_server)
+        .await;
+
     let response = test_app.post_subscriptions(body.into()).await;
 
     assert_eq!(200, response.status().as_u16());
+}
 
-    let saved = sqlx::query!("SELECT email, name FROM subscriptions")
+#[tokio::test]
+async fn subscribe_persists_the_new_subscriber() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    let saved = sqlx::query!("SELECT email, name, status FROM subscriptions")
         .fetch_one(&test_app.db_pool)
         .await
         .expect("Failed to fetch saved subscription.");
 
     assert_eq!(saved.email, "ursula_le_guin@gmail.com");
     assert_eq!(saved.name, "le guin");
+    assert_eq!(saved.status, "pending_confirmation");
 }
 
 #[tokio::test]
@@ -57,4 +86,44 @@ async fn subscribe_returns_a_400_when_fields_are_present_but_invalid() {
             "The API did not return a 200 OK when the payload was {description}."
         );
     }
+}
+
+#[tokio::test]
+async fn subscribe_sends_a_confirmation_email_for_valid_data() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+}
+
+#[tokio::test]
+async fn subscribe_sends_a_confirmation_email_with_a_link() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        // No more expectation, test is focused on another aspect of app behavior
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let email_request = &test_app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = test_app.get_confirmation_links(email_request);
+
+    assert_eq!(confirmation_links.html, confirmation_links.plain_text);
 }

--- a/tests/api/subscriptions_confirm.rs
+++ b/tests/api/subscriptions_confirm.rs
@@ -1,0 +1,76 @@
+use wiremock::{
+    matchers::{method, path},
+    Mock, ResponseTemplate,
+};
+
+use crate::helpers::spawn_app;
+
+#[tokio::test]
+async fn confirmations_without_token_are_rejected_with_a_400() {
+    let test_app = spawn_app().await;
+
+    let response = reqwest::get(&format!("{}/subscriptions/confirm", test_app.address))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status().as_u16(), 400);
+}
+
+#[tokio::test]
+async fn the_link_returned_by_subscribe_returns_a_200_if_called() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        // No more expectation, test is focused on another aspect of app behavior
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let email_request = &test_app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = test_app.get_confirmation_links(email_request);
+
+    let response = reqwest::get(confirmation_links.html).await.unwrap();
+
+    assert_eq!(response.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn clicking_the_confirmation_link_confirms_a_subscriber() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        // No more expectation, test is focused on another aspect of app behavior
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let email_request = &test_app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = test_app.get_confirmation_links(email_request);
+
+    reqwest::get(confirmation_links.html)
+        .await
+        .unwrap()
+        .error_for_status() // So we return an error if non-200 (I think)
+        .unwrap();
+
+    let saved = sqlx::query!("SELECT email, name, status FROM subscriptions",)
+        .fetch_one(&test_app.db_pool)
+        .await
+        .expect("Failed to fetch saved subscriptions.");
+
+    assert_eq!(saved.email, "ursula_le_guin@gmail.com");
+    assert_eq!(saved.name, "le guin");
+    assert_eq!(saved.status, "confirmed");
+}


### PR DESCRIPTION
* Generate unique token and insert into `subscription_tokens` table when signing up new users
* Email confirmation link to user with uuid token as query param
* get request to confirmation link updates subscriber status 