### PR TITLE
refactor: improving subscriptions endpoint err handling

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -93,7 +93,7 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
             configuration_directory.join("base.yaml"),
         ))
         .add_source(config::File::from(
-            configuration_directory.join(&environment_filename),
+            configuration_directory.join(environment_filename),
         ))
         // Add in settings from env variables
         .add_source(

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Form, State},
-    http::StatusCode,
+    http,
     response::IntoResponse,
 };
 use chrono::Utc;
@@ -32,59 +32,126 @@ impl TryFrom<FormData> for NewSubscriber {
     }
 }
 
+pub enum SubscribeError {
+    Validation(String),
+    StoreToken(StoreTokenError),
+    SendEmail(reqwest::Error),
+    Pool(sqlx::Error),
+    InsertSubscriber(sqlx::Error),
+    TransactionCommit(sqlx::Error),
+}
+
+impl std::error::Error for SubscribeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SubscribeError::StoreToken(e) => Some(e),
+            SubscribeError::SendEmail(e) => Some(e),
+            SubscribeError::InsertSubscriber(e) => Some(e),
+            SubscribeError::Pool(e) => Some(e),
+            SubscribeError::TransactionCommit(e) => Some(e),
+            SubscribeError::Validation(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Debug for SubscribeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
+impl std::fmt::Display for SubscribeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SubscribeError::StoreToken(_) => write!(
+                f,
+                "Failed to store the confirmation token for a new subscriber."
+            ),
+            SubscribeError::SendEmail(_) => write!(f, "Failed to send a confirmation email."),
+            SubscribeError::Validation(e) => write!(f, "{}", e),
+            SubscribeError::InsertSubscriber(_) => {
+                write!(f, "Failed to insert new subscriber in the database.")
+            }
+            SubscribeError::Pool(_) => {
+                write!(f, "Failed to acquire a Postgres connection from the pool.")
+            }
+            SubscribeError::TransactionCommit(_) => write!(
+                f,
+                "Failed to commit SQL transaction to store a new subscriber"
+            ),
+        }
+    }
+}
+
+impl IntoResponse for SubscribeError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            SubscribeError::Validation(_) => http::StatusCode::BAD_REQUEST.into_response(),
+            SubscribeError::InsertSubscriber(_)
+            | SubscribeError::Pool(_)
+            | SubscribeError::TransactionCommit(_)
+            | SubscribeError::SendEmail(_)
+            | SubscribeError::StoreToken(_) => {
+                http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
+        }
+    }
+}
+
+impl From<reqwest::Error> for SubscribeError {
+    fn from(e: reqwest::Error) -> Self {
+        Self::SendEmail(e)
+    }
+}
+
+impl From<StoreTokenError> for SubscribeError {
+    fn from(e: StoreTokenError) -> Self {
+        Self::StoreToken(e)
+    }
+}
+
+impl From<String> for SubscribeError {
+    fn from(e: String) -> Self {
+        Self::Validation(e)
+    }
+}
+
 #[tracing::instrument(
     name = "Adding a new subscriber",
     skip(form, app_state),
     fields(
         subscriber_email = %form.email,
         subscriber_name = %form.name,
-    )
+    ),
+    err(Debug),
 )]
 pub async fn subscribe(
     State(app_state): State<Arc<AppState>>,
     Form(form): Form<FormData>,
-) -> impl IntoResponse {
-    let new_subscriber = match form.try_into() {
-        Ok(new_subscriber) => new_subscriber,
-        Err(_) => return StatusCode::BAD_REQUEST,
-    };
+) -> Result<impl IntoResponse, SubscribeError> {
+    let new_subscriber = form.try_into()?;
+    let mut transaction = app_state.pool.begin().await.map_err(SubscribeError::Pool)?;
 
-    let mut transaction = match app_state.pool.begin().await {
-        Ok(transaction) => transaction,
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
-    };
-
-    let subscriber_id = match insert_subscriber(&mut transaction, &new_subscriber).await {
-        Ok(subscriber_id) => subscriber_id,
-        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR,
-    };
+    let subscriber_id = insert_subscriber(&mut transaction, &new_subscriber)
+        .await
+        .map_err(SubscribeError::InsertSubscriber)?;
     let subscription_token = generate_subscription_token();
 
-    if store_token(&mut transaction, subscriber_id, &subscription_token)
+    store_token(&mut transaction, subscriber_id, &subscription_token).await?;
+    transaction
+        .commit()
         .await
-        .is_err()
-    {
-        return StatusCode::INTERNAL_SERVER_ERROR;
-    }
+        .map_err(SubscribeError::TransactionCommit)?;
 
-    if transaction.commit().await.is_err() {
-        return StatusCode::INTERNAL_SERVER_ERROR;
-    }
-
-    // Send an email to the new subscriber
-    if send_confirmation_email(
+    send_confirmation_email(
         &app_state.email_client,
         new_subscriber,
         &app_state.application_base_url,
         &subscription_token,
     )
-    .await
-    .is_err()
-    {
-        return StatusCode::INTERNAL_SERVER_ERROR;
-    }
+    .await?;
 
-    StatusCode::OK
+    Ok(http::StatusCode::OK)
 }
 
 #[tracing::instrument(
@@ -95,7 +162,7 @@ pub async fn store_token(
     transaction: &mut Transaction<'_, Postgres>,
     subscriber_id: Uuid,
     subscription_token: &str,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), StoreTokenError> {
     sqlx::query!(
         r#"INSERT INTO subscription_tokens (subscription_token, subscriber_id)
         VALUES ($1, $2)"#,
@@ -104,10 +171,45 @@ pub async fn store_token(
     )
     .execute(transaction)
     .await
-    .map_err(|e| {
-        tracing::error!("Failed to execute query: {:?}", e);
-        e
-    })?;
+    .map_err(StoreTokenError)?;
+    Ok(())
+}
+
+pub struct StoreTokenError(sqlx::Error);
+
+impl std::error::Error for StoreTokenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // Compiler transparently casts `&sqlx::Error` into a `&dyn Error`
+        Some(&self.0)
+    }
+}
+
+impl std::fmt::Debug for StoreTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
+impl std::fmt::Display for StoreTokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "A database error was encountered while \
+            trying to store a subscription token."
+        )
+    }
+}
+
+fn error_chain_fmt(
+    e: &impl std::error::Error,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    writeln!(f, "{}\n", e)?;
+    let mut current = e.source();
+    while let Some(cause) = current {
+        writeln!(f, "Caused by:\n\t{}", cause)?;
+        current = cause.source();
+    }
     Ok(())
 }
 

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -127,3 +127,20 @@ async fn subscribe_sends_a_confirmation_email_with_a_link() {
 
     assert_eq!(confirmation_links.html, confirmation_links.plain_text);
 }
+
+#[tokio::test]
+async fn subscribe_fails_if_there_is_a_fatal_database_error() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    // Sabotage the database
+    sqlx::query!("ALTER TABLE subscription_tokens DROP COLUMN subscription_token;",)
+        .execute(&test_app.db_pool)
+        .await
+        .unwrap();
+
+    let response = test_app.post_subscriptions(body.into()).await;
+
+    assert_eq!(response.status().as_u16(), 500);
+}


### PR DESCRIPTION
* This PR contains all the error handling boilerplate added to improve the logging when errors occur
* The next PR will contain the condensed version using the `thiserror` crate