### PR TITLE
refactor: improving error handling with anyhow and thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "assert-json-diff"
@@ -1869,18 +1869,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2519,6 +2519,7 @@ dependencies = [
 name = "zero2prod"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "axum",
  "chrono",
  "claims",
@@ -2537,6 +2538,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "sqlx",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ unicode-segmentation = "1.10.0"
 validator = "0.16.0"
 axum = "0.6.1"
 rand = { version = "0.8.5", features = ["std_rng"] }
+thiserror = "1.0.38"
+anyhow = "1.0.68"
 
 [dependencies.sqlx]
 version = "0.6.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod email_client;
 pub mod routes;
 pub mod startup;
 pub mod telemetry;
+pub mod util;

--- a/src/routes/health_check.rs
+++ b/src/routes/health_check.rs
@@ -1,5 +1,6 @@
-use axum::{http::StatusCode, response::IntoResponse};
+use axum::{http, response::IntoResponse};
 
+#[tracing::instrument(name = "Health check")]
 pub async fn health_check() -> impl IntoResponse {
-    StatusCode::OK
+    http::StatusCode::OK
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,12 @@
+pub fn error_chain_fmt(
+    e: &impl std::error::Error,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    writeln!(f, "{}\n", e)?;
+    let mut current = e.source();
+    while let Some(cause) = current {
+        writeln!(f, "Caused by:\n\t{}", cause)?;
+        current = cause.source();
+    }
+    Ok(())
+}

--- a/tests/api/subscriptions.rs
+++ b/tests/api/subscriptions.rs
@@ -129,13 +129,30 @@ async fn subscribe_sends_a_confirmation_email_with_a_link() {
 }
 
 #[tokio::test]
-async fn subscribe_fails_if_there_is_a_fatal_database_error() {
+async fn subscribe_fails_if_there_is_a_fatal_subscription_tokens_database_error() {
     let test_app = spawn_app().await;
 
     let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
 
     // Sabotage the database
     sqlx::query!("ALTER TABLE subscription_tokens DROP COLUMN subscription_token;",)
+        .execute(&test_app.db_pool)
+        .await
+        .unwrap();
+
+    let response = test_app.post_subscriptions(body.into()).await;
+
+    assert_eq!(response.status().as_u16(), 500);
+}
+
+#[tokio::test]
+async fn subscribe_fails_if_there_is_a_fatal_subscriptions_database_error() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    // Sabotage the database
+    sqlx::query!("ALTER TABLE subscriptions DROP COLUMN email;",)
         .execute(&test_app.db_pool)
         .await
         .unwrap();

--- a/tests/api/subscriptions_confirm.rs
+++ b/tests/api/subscriptions_confirm.rs
@@ -74,3 +74,96 @@ async fn clicking_the_confirmation_link_confirms_a_subscriber() {
     assert_eq!(saved.name, "le guin");
     assert_eq!(saved.status, "confirmed");
 }
+
+#[tokio::test]
+async fn confirm_fails_if_there_is_a_fatal_subscription_tokens_database_error() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        // No more expectation, test is focused on another aspect of app behavior
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let email_request = &test_app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = test_app.get_confirmation_links(email_request);
+
+    // Sabotage the database
+    sqlx::query!("ALTER TABLE subscription_tokens DROP COLUMN subscription_token;",)
+        .execute(&test_app.db_pool)
+        .await
+        .unwrap();
+
+    let response = reqwest::get(confirmation_links.html)
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status().as_u16(), 500);
+}
+
+#[tokio::test]
+async fn confirm_fails_if_there_is_a_fatal_subscriptions_database_error() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        // No more expectation, test is focused on another aspect of app behavior
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let email_request = &test_app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = test_app.get_confirmation_links(email_request);
+
+    // Sabotage the database
+    sqlx::query!("ALTER TABLE subscriptions DROP COLUMN status;",)
+        .execute(&test_app.db_pool)
+        .await
+        .unwrap();
+
+    let response = reqwest::get(confirmation_links.html)
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status().as_u16(), 500);
+}
+
+#[tokio::test]
+async fn confirm_returns_401_with_invalid_subscription_token() {
+    let test_app = spawn_app().await;
+
+    let body = "name=le%20guin&email=ursula_le_guin%40gmail.com";
+
+    Mock::given(path("/email"))
+        .and(method("POST"))
+        .respond_with(ResponseTemplate::new(200))
+        // No more expectation, test is focused on another aspect of app behavior
+        .mount(&test_app.email_server)
+        .await;
+
+    test_app.post_subscriptions(body.into()).await;
+
+    // Assert
+    let email_request = &test_app.email_server.received_requests().await.unwrap()[0];
+    let confirmation_links = test_app.get_confirmation_links(email_request);
+
+    let mut html_link = confirmation_links.html;
+    html_link.set_query(Some("subscription_token=my-invalid-token"));
+
+    let response = reqwest::get(html_link)
+        .await
+        .expect("Failed to execute request");
+
+    assert_eq!(response.status().as_u16(), 401);
+}


### PR DESCRIPTION
* Updated refactored error handling for the `subscriptions` endpoint to take advantage of `anyhow` and `thiserror` for readability and maintainability
* Refactored error handling for the `subscriptions/confirm` endpoint to improve error logging
* Added tracing to the `health_check` endpoint since telemetry hadnt been added up till this point
* Wrote tests for both subscription endpoints to confirm dropping specific databases resulted in expected errors and logging messages