### PR TITLE
feat: adding login functionality with web pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,6 +2267,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
 name = "uuid"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2570,6 +2582,9 @@ dependencies = [
  "claims",
  "config",
  "fake",
+ "hex",
+ "hmac",
+ "htmlescape",
  "http",
  "hyper",
  "linkify",
@@ -2582,6 +2597,7 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror",
  "tokio",
@@ -2592,6 +2608,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "unicode-segmentation",
+ "urlencoding",
  "uuid",
  "validator",
  "wiremock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ thiserror = "1.0.38"
 anyhow = "1.0.68"
 base64 = "0.20.0"
 argon2 = { version = "0.4.1", features = ["std"] }
+urlencoding = "2.1.2"
+htmlescape = "0.3.1"
+hmac = { version = "0.12.1", features = ["std"] }
+sha2 = "0.10.6"
+hex = "0.4.3"
 
 [dependencies.sqlx]
 version = "0.6.2"

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -1,5 +1,6 @@
 application:
   port: 8000
+  hmac_secret: "long-and-very-secret-random-key-needed-for-verifying-integrity"
 database:
   host: "127.0.0.1"
   port: 5432

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -1,0 +1,91 @@
+use anyhow::Context;
+use argon2::{Argon2, PasswordHash, PasswordVerifier};
+use secrecy::{ExposeSecret, Secret};
+use sqlx::PgPool;
+
+use crate::telemetry::spawn_blocking_with_tracing;
+
+#[derive(thiserror::Error, Debug)]
+pub enum AuthError {
+    #[error("Invalid credentials.")]
+    InvalidCredentials(#[source] anyhow::Error),
+    #[error(transparent)]
+    Unexpected(#[from] anyhow::Error),
+}
+
+pub struct Credentials {
+    pub username: String,
+    pub password: Secret<String>,
+}
+
+#[tracing::instrument(name = "Validate credentials", skip(credentials, pool), err(Debug))]
+pub async fn validate_credentials(
+    credentials: Credentials,
+    pool: &PgPool,
+) -> Result<uuid::Uuid, AuthError> {
+    let mut user_id = None;
+    let mut expected_password_hash = Secret::new(
+        "$argon2id$v=19$m=15000,t=2,p=1$\
+                gZiV/M1gPc22ElAH/Jh1Hw$\
+                CWOrkoo7oJBQ/iyh7uJ0LO2aLEfrHwTWllSAxT0zRno"
+            .to_string(),
+    );
+
+    if let Some((stored_user_id, stored_password_hash)) =
+        get_stored_credentials(&credentials.username, pool).await?
+    {
+        user_id = Some(stored_user_id);
+        expected_password_hash = stored_password_hash;
+    }
+
+    spawn_blocking_with_tracing(move || {
+        verify_password_hash(expected_password_hash, credentials.password)
+    })
+    .await
+    // spawn_blocking is fallible - we have a nested Result here!
+    .context("Failed to spawn blocking task.")??;
+
+    user_id.ok_or_else(|| AuthError::InvalidCredentials(anyhow::anyhow!("Unknown username.")))
+}
+
+#[tracing::instrument(
+    name = "Verify password hash",
+    skip(expected_password_hash, password_candidate),
+    err(Debug)
+)]
+fn verify_password_hash(
+    expected_password_hash: Secret<String>,
+    password_candidate: Secret<String>,
+) -> Result<(), AuthError> {
+    let expected_password_hash = PasswordHash::new(expected_password_hash.expose_secret())
+        .context("Failed to parse hash in PHC string format.")?;
+
+    Argon2::default()
+        .verify_password(
+            password_candidate.expose_secret().as_bytes(),
+            &expected_password_hash,
+        )
+        .context("Invalid password.")
+        .map_err(AuthError::InvalidCredentials)
+}
+
+#[tracing::instrument(name = "Get stored credentials", skip(username, pool), err(Debug))]
+async fn get_stored_credentials(
+    username: &str,
+    pool: &PgPool,
+) -> Result<Option<(uuid::Uuid, Secret<String>)>, anyhow::Error> {
+    let row = sqlx::query!(
+        r#"
+        SELECT user_id, password_hash
+        FROM users
+        WHERE username = $1
+        "#,
+        username,
+    )
+    .fetch_optional(pool)
+    .await
+    .context("Failed to perform a query to retrieve stored credentials.")?
+    .map(|row| (row.user_id, Secret::new(row.password_hash)));
+
+    Ok(row)
+}

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -41,6 +41,7 @@ pub struct ApplicationSettings {
     pub port: u16,
     pub host: String,
     pub base_url: String,
+    pub hmac_secret: Secret<String>,
 }
 
 #[derive(serde::Deserialize, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod authentication;
 pub mod configuration;
 pub mod domain;
 pub mod email_client;

--- a/src/routes/home/home.html
+++ b/src/routes/home/home.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Home</title>
+  </head>
+  <body>
+    <div>Welcome to our newsletter!</div>
+  </body>
+</html>

--- a/src/routes/home/mod.rs
+++ b/src/routes/home/mod.rs
@@ -1,0 +1,7 @@
+use axum::response::{Html, IntoResponse};
+
+#[tracing::instrument(name = "Home")]
+pub async fn home() -> impl IntoResponse {
+    // `Html` auto-sets `content-type` to `text/html`
+    Html(include_str!("home.html"))
+}

--- a/src/routes/login/get.rs
+++ b/src/routes/login/get.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    response::{Html, IntoResponse},
+};
+use hmac::{Hmac, Mac};
+use secrecy::ExposeSecret;
+
+use crate::startup::{AppState, HmacSecret};
+
+#[derive(serde::Deserialize)]
+pub struct QueryParams {
+    error: String,
+    tag: String,
+}
+
+impl QueryParams {
+    fn verify(self, secret: &HmacSecret) -> Result<String, anyhow::Error> {
+        let tag = hex::decode(self.tag)?;
+        let query_string = format!("error={}", urlencoding::Encoded::new(&self.error));
+
+        let mut mac =
+            Hmac::<sha2::Sha256>::new_from_slice(secret.0.expose_secret().as_bytes()).unwrap();
+        mac.update(query_string.as_bytes());
+        mac.verify_slice(&tag)?;
+
+        Ok(self.error)
+    }
+}
+
+#[tracing::instrument(name = "Login form", skip(query, app_state))]
+pub async fn login_form(
+    State(app_state): State<Arc<AppState>>,
+    query: Option<Query<QueryParams>>,
+) -> impl IntoResponse {
+    let error_html = match query {
+        None => "".into(),
+        Some(query) => match query.0.verify(&app_state.hmac_secret) {
+            Ok(error) => {
+                format!("<p><i>{}</i></p>", htmlescape::encode_minimal(&error))
+            }
+            Err(e) => {
+                tracing::warn!(
+                  error.message = %e,
+                  error.cause_chain = ?e,
+                  "Failed to verify query parameters using the HMAC tag"
+                );
+                "".into()
+            }
+        },
+    };
+
+    Html(format!(
+        r#"<!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+          <title>Login</title>
+        </head>
+        <body>
+          {error_html}
+          <form action="/login" method="post">
+            <label
+              >Username
+              <input type="text" placeholder="Enter Username" name="username" />
+            </label>
+            <label
+              >Password
+              <input type="password" placeholder="Enter Password" name="password" />
+            </label>
+            <button type="submit">Login</button>
+          </form>
+        </body>
+      </html>
+      "#
+    ))
+}

--- a/src/routes/login/login.html
+++ b/src/routes/login/login.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <title>Login</title>
+  </head>
+  <body>
+    <form action="/login" method="post">
+      <label
+        >Username
+        <input type="text" placeholder="Enter Username" name="username" />
+      </label>
+      <label
+        >Password
+        <input type="password" placeholder="Enter Password" name="password" />
+      </label>
+      <button type="submit">Login</button>
+    </form>
+  </body>
+</html>

--- a/src/routes/login/mod.rs
+++ b/src/routes/login/mod.rs
@@ -1,0 +1,5 @@
+mod get;
+mod post;
+
+pub use get::login_form;
+pub use post::login;

--- a/src/routes/login/post.rs
+++ b/src/routes/login/post.rs
@@ -1,0 +1,94 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Form, State},
+    http,
+    response::IntoResponse,
+};
+use hmac::{Hmac, Mac};
+use secrecy::{ExposeSecret, Secret};
+
+use crate::{
+    authentication::{validate_credentials, AuthError, Credentials},
+    startup::AppState,
+    util::error_chain_fmt,
+};
+
+#[derive(serde::Deserialize)]
+pub struct FormData {
+    username: String,
+    password: Secret<String>,
+}
+
+#[derive(thiserror::Error)]
+pub enum LoginError {
+    #[error("Authentication failed")]
+    Auth(#[source] anyhow::Error),
+    #[error("Something went wrong")]
+    Unexpected(#[from] anyhow::Error),
+}
+
+impl std::fmt::Debug for LoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        error_chain_fmt(self, f)
+    }
+}
+
+impl IntoResponse for LoginError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            LoginError::Unexpected(_) => http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            // ! Not sure we even need this or should be impl IntoResponse
+            LoginError::Auth(_) => http::StatusCode::UNAUTHORIZED.into_response(),
+        }
+    }
+}
+
+#[tracing::instrument(
+  name = "Login",
+  skip(form, app_state),
+  fields(username=tracing::field::Empty, user_id=tracing::field::Empty),
+  err(Debug)
+)]
+pub async fn login(
+    State(app_state): State<Arc<AppState>>,
+    Form(form): Form<FormData>,
+) -> Result<impl IntoResponse, impl IntoResponse> {
+    let credentials = Credentials {
+        username: form.username,
+        password: form.password,
+    };
+    tracing::Span::current().record("username", &tracing::field::display(&credentials.username));
+
+    match validate_credentials(credentials, &app_state.pool).await {
+        Ok(user_id) => {
+            tracing::Span::current().record("user_id", &tracing::field::display(&user_id));
+
+            Ok((http::StatusCode::SEE_OTHER, [(http::header::LOCATION, "/")]))
+        }
+        Err(e) => {
+            let e = match e {
+                AuthError::InvalidCredentials(_) => LoginError::Auth(e.into()),
+                AuthError::Unexpected(_) => LoginError::Unexpected(e.into()),
+            };
+
+            let query_string = format!("error={}", urlencoding::Encoded::new(e.to_string()));
+
+            let hmac_tag = {
+                let mut mac = Hmac::<sha2::Sha256>::new_from_slice(
+                    app_state.hmac_secret.0.expose_secret().as_bytes(),
+                )
+                .unwrap();
+                mac.update(query_string.as_bytes());
+                mac.finalize().into_bytes()
+            };
+            Err((
+                http::StatusCode::SEE_OTHER,
+                [(
+                    http::header::LOCATION,
+                    format!("/login?{query_string}&tag={hmac_tag:x}"),
+                )],
+            ))
+        }
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,9 +1,13 @@
 mod health_check;
+mod home;
+mod login;
 mod newsletters;
 mod subscriptions;
 mod subscriptions_confirm;
 
 pub use health_check::health_check;
+pub use home::home;
+pub use login::{login, login_form};
 pub use newsletters::publish_newsletter;
 pub use subscriptions::{subscribe, FormData};
 pub use subscriptions_confirm::confirm;


### PR DESCRIPTION
This PR covers 10.5 Login Forms to 10.6.4.8 when we add cookies

* Added a homepage route with a generic html welcome message 
* Added a login route that sends an html form for the user to login
* Uses HMAC query parameter on login failure to dynamically show an error message
*  