### PR TITLE
feat: adding cookie based error handling and redirects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+dependencies = [
+ "axum",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "mime",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +294,38 @@ dependencies = [
  "serde_json",
  "toml",
  "yaml-rust",
+]
+
+[[package]]
+name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "base64 0.20.0",
+ "hmac",
+ "percent-encoding",
+ "rand 0.8.5",
+ "sha2",
+ "subtle",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4b6aa369f41f5faa04bb80c9b1f4216ea81646ed6124d76ba5c49a7aafd9cd"
+dependencies = [
+ "cookie",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1317,12 +1369,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]
@@ -1482,6 +1556,8 @@ checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64 0.13.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1497,6 +1573,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "proc-macro-hack",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -2577,13 +2654,12 @@ dependencies = [
  "anyhow",
  "argon2",
  "axum",
+ "axum-extra",
  "base64 0.20.0",
  "chrono",
  "claims",
  "config",
  "fake",
- "hex",
- "hmac",
  "htmlescape",
  "http",
  "hyper",
@@ -2597,7 +2673,6 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
- "sha2",
  "sqlx",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,7 @@ base64 = "0.20.0"
 argon2 = { version = "0.4.1", features = ["std"] }
 urlencoding = "2.1.2"
 htmlescape = "0.3.1"
-hmac = { version = "0.12.1", features = ["std"] }
-sha2 = "0.10.6"
-hex = "0.4.3"
+axum-extra = { version = "0.4.2", features = ["cookie", "cookie-signed"] }
 
 [dependencies.sqlx]
 version = "0.6.2"
@@ -53,7 +51,7 @@ features = [
 [dependencies.reqwest]
 version = "0.11.12"
 default-features = false
-features = ["json", "rustls-tls"]
+features = ["json", "rustls-tls", "cookies"]
 
 [dev-dependencies]
 claims = "0.7.1"

--- a/configuration/base.yaml
+++ b/configuration/base.yaml
@@ -1,6 +1,6 @@
 application:
   port: 8000
-  hmac_secret: "long-and-very-secret-random-key-needed-for-verifying-integrity"
+  hmac_secret: "long-and-very-secret-random-key-needed-for-verifying-integrity-a"
 database:
   host: "127.0.0.1"
   port: 5432

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -41,6 +41,8 @@ pub struct ApplicationSettings {
     pub port: u16,
     pub host: String,
     pub base_url: String,
+    /// Must be 64 characters long bc the `Key` for signed
+    /// cookies requires a 64 byte key
     pub hmac_secret: Secret<String>,
 }
 

--- a/src/routes/newsletters.rs
+++ b/src/routes/newsletters.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::Context;
 use axum::{
     extract::{Json, State},
@@ -67,7 +65,7 @@ impl IntoResponse for PublishError {
 )]
 pub async fn publish_newsletter(
     headers: header::HeaderMap,
-    State(app_state): State<Arc<AppState>>,
+    State(app_state): State<AppState>,
     Json(body): Json<BodyData>,
 ) -> Result<impl IntoResponse, PublishError> {
     let credentials = basic_authentication(&headers).map_err(PublishError::Auth)?;

--- a/src/routes/subscriptions.rs
+++ b/src/routes/subscriptions.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::Context;
 use axum::{
     extract::{Form, State},
@@ -68,7 +66,7 @@ impl IntoResponse for SubscribeError {
     err(Debug),
 )]
 pub async fn subscribe(
-    State(app_state): State<Arc<AppState>>,
+    State(app_state): State<AppState>,
     Form(form): Form<FormData>,
 ) -> Result<impl IntoResponse, SubscribeError> {
     let new_subscriber = form.try_into().map_err(SubscribeError::Validation)?;

--- a/src/routes/subscriptions_confirm.rs
+++ b/src/routes/subscriptions_confirm.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use anyhow::Context;
 use axum::{
     extract::{Query, State},
@@ -45,7 +43,7 @@ impl IntoResponse for ConfirmError {
     err(Debug)
 )]
 pub async fn confirm(
-    State(app_state): State<Arc<AppState>>,
+    State(app_state): State<AppState>,
     Query(parameters): Query<Parameters>,
 ) -> Result<impl IntoResponse, ConfirmError> {
     let id = get_subscriber_id_from_token(&app_state.pool, &parameters.subscription_token)

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -115,9 +115,6 @@ pub fn run(
         },
     ));
 
-    // TODO: Need to test it out
-    // * Issue was I was using Arc<AppState> in all my handlers before
-    // * I should be okay since im still using Arc but its wrapped in a new type
     let app = Router::new()
         .route("/health_check", get(health_check))
         .route("/subscriptions", post(subscribe))

--- a/tests/api/login.rs
+++ b/tests/api/login.rs
@@ -1,0 +1,25 @@
+use crate::helpers::{assert_is_redirect_to, spawn_app};
+
+#[tokio::test]
+async fn an_error_flash_message_is_set_on_failure() {
+    // Arrange
+    let test_app = spawn_app().await;
+
+    // Act - Part 1 - Try to login
+    let login_body = serde_json::json!({
+      "username": "random-username",
+      "password": "random-password"
+    });
+    let response = test_app.post_login(&login_body).await;
+
+    // Assert
+    assert_is_redirect_to(&response, "/login");
+
+    // Act - Part 2 - Follow the redirect
+    let html_page = test_app.get_login_html().await;
+    assert!(html_page.contains(r#"<p><i>Authentication failed</i></p>"#));
+
+    // Act - Part 3 - Reload the login page
+    let html_page = test_app.get_login_html().await;
+    assert!(!html_page.contains(r#"<p><i>Authentication failed</i></p>"#));
+}

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,5 +1,6 @@
 mod health_check;
 mod helpers;
+mod login;
 mod newsletters;
 mod subscriptions;
 mod subscriptions_confirm;


### PR DESCRIPTION
This PR covers from 10.6.4.8 adding cookies to 10.7 Sessions

* Add signed cookies instead of using query parameters for failed logins
* Remove cookies on `GET /login` requests
* Wrapped `reqwest` calls in tests so we could leverage cookies